### PR TITLE
Add lib-pcg-ts back to lib-pcg-avm.code-workspace

### DIFF
--- a/lib-pcg-avm.code-workspace
+++ b/lib-pcg-avm.code-workspace
@@ -14,8 +14,11 @@
       "path": "projects/lib-pcg-pyteal"
     },
     {
-      "path": "projects/unified-tests"
+      "path": "projects/lib-pcg-ts"
     },
+    {
+      "path": "projects/unified-tests"
+    }
   ],
   "settings": {
     "files.exclude": {


### PR DESCRIPTION
It appears that `lib-pcg-ts` was removed in the [refreshed unified tests template](https://github.com/CiottiGiorgio/lib-pcg-avm/commit/f9e3caf88998221f79f72ec09e52a9108f76ed5e#diff-9b49529eec75e6e31bc54a24e97c9ff752d748f5b10d9cb63a69db4b784fa20fL14)  commit. Even if `lib-pcg-algots` is meant to be a successor, I think that `lib-pcg-ts` should be included in the workspace config until `lib-pcg-ts` is removed entirely. 